### PR TITLE
Add compactor and compression configurations to box.json file.

### DIFF
--- a/box.json
+++ b/box.json
@@ -16,6 +16,10 @@
             "in": "vendor"
         }
     ],
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Php"
+    ],
+    "compression": "GZ",
     "git-version": "package_version",
     "main": "bin/drupalvm",
     "output": "drupalvm.phar",


### PR DESCRIPTION
Minor updates to box.json file adding configurations to compact size of generated `phar` file

As you can see the size file was decreased from 2.8M to 633K 
![drupalvm.phar](https://monosnap.com/file/5Kc8TaH7CsiheHnZThq8QDCove1f70.png)
